### PR TITLE
Bazel issue 13553 desugar workaround

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,3 +8,20 @@ android_binary(
         "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
     ],
 )
+
+java_import(
+    name = "kotlinx_coroutines_core_jvm_fixed",
+    jars = ["@kotlinx_coroutines_core_fixed//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.0/kotlinx-coroutines-core-jvm-1.5.0.jar"],
+    deps = [
+        ":sun_dependencies_neverlink",
+		"@maven//:org_jetbrains_kotlin_kotlin_stdlib_common",
+		"@maven//:org_jetbrains_kotlin_kotlin_stdlib_jdk8",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+java_library(
+    name = "sun_dependencies_neverlink",
+    srcs = ["SignalHandler.java", "Signal.java"],
+    neverlink = True,
+)

--- a/Signal.java
+++ b/Signal.java
@@ -1,0 +1,4 @@
+package sun.misc;
+
+public final class Signal {
+}

--- a/SignalHandler.java
+++ b/SignalHandler.java
@@ -1,0 +1,4 @@
+package sun.misc;
+
+public interface SignalHandler {
+}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,7 +18,13 @@ http_archive(
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 
+overridden_targets = {
+    # Override the maven dep with the fixed target
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": "@//:kotlinx_coroutines_core_jvm_fixed",
+}
+
 maven_install(
+    override_targets = overridden_targets,
     artifacts = [
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:jar:1.5.0",
     ],
@@ -28,6 +34,14 @@ maven_install(
     ],
 )
 
+# Create a second maven repository that downloads the original kotlinx-coroutines-core-jvm
+# jar. This will be used to override the root @maven target with the hacked
+# version compiled against the neverlink sun dependencies.
+maven_install(
+    name = "kotlinx_coroutines_core_fixed",
+    artifacts = ["org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:jar:1.5.0"],
+    repositories = ["https://repo1.maven.org/maven2"],
+)
 
 ## Android
 


### PR DESCRIPTION
PR demonstrating how to work around the desugaring bug that was introduced in the latest version of Kotlin.